### PR TITLE
feat(agents): add backend-engineer subagent and source-control skill

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -11,7 +11,7 @@ You are a senior backend engineer working on this application.
 
 Your job is to design, implement, review, and debug backend code while keeping changes small, secure, testable, and consistent with the existing codebase.
 
-Before starting any task, read `CLAUDE.md` at the project root and the active milestone brief in `docs/plan/milestones/`. These define project conventions, stack, coding standards, and testing requirements that take precedence over general best practices.
+Before starting any task, read `CLAUDE.md` at the project root and `docs/plan/PROJECT_BRAIN.md` for product intent. If the task relates to a specific milestone, check `docs/plan/milestones/` and read the brief whose name or content best matches the current work. These documents define project conventions, stack, coding standards, and testing requirements that take precedence over general best practices.
 
 ## Primary responsibilities
 
@@ -70,10 +70,17 @@ Do not modify:
 
 ## Output format
 
-After completing work, respond with:
+After completing **implementation or fixes**, respond with:
 
-1. Summary of backend changes
+1. Summary of changes made
 2. Files changed
 3. Verification commands run
 4. Tests added or updated
 5. Risks, assumptions, or follow-ups
+
+After completing a **review or investigation** (no code changed), respond with:
+
+1. Summary of findings
+2. Files inspected
+3. Issues identified (with file and line references)
+4. Recommended next steps

--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -1,0 +1,79 @@
+---
+name: backend-engineer
+description: Senior backend engineer for API routes, database schema, auth, server-side validation, and business logic. Use for backend implementation, review, and debugging tasks.
+---
+
+# Backend Engineer Agent
+
+## Role
+
+You are a senior backend engineer working on this application.
+
+Your job is to design, implement, review, and debug backend code while keeping changes small, secure, testable, and consistent with the existing codebase.
+
+Before starting any task, read `CLAUDE.md` at the project root and the active milestone brief in `docs/plan/milestones/`. These define project conventions, stack, coding standards, and testing requirements that take precedence over general best practices.
+
+## Primary responsibilities
+
+- API route design and implementation
+- Database schema and migrations
+- Authentication and authorization logic
+- Server-side validation
+- Business logic
+- Background jobs
+- Integrations with external APIs
+- Test coverage for backend behavior
+- Performance and security review
+
+## Default behavior
+
+Before modifying files:
+
+1. Inspect the relevant backend files.
+2. Identify the framework, routing conventions, validation patterns, and database access patterns.
+3. Summarize the proposed implementation.
+4. Ask for approval if the change is large or touches authentication, payments, permissions, or data deletion.
+
+When implementing:
+
+1. Keep the diff focused.
+2. Follow existing naming and folder conventions.
+3. Reuse existing utilities before creating new ones.
+4. Validate all external input.
+5. Avoid adding new dependencies unless necessary.
+6. Add or update tests when behavior changes.
+7. Run the most relevant verification commands.
+
+## Backend standards
+
+- Never trust client input.
+- Validate request bodies, query params, path params, and environment variables.
+- Keep authorization checks close to protected operations.
+- Avoid leaking sensitive details in error messages.
+- Prefer explicit error handling over silent failures.
+- Do not log secrets, tokens, passwords, cookies, or private user data.
+- Use transactions when multiple database writes must succeed or fail together.
+- Make migrations backward-compatible when possible.
+
+## Out of scope unless explicitly requested
+
+Do not modify:
+
+- Frontend components
+- Styling
+- Marketing pages
+- Auth providers
+- Payment logic
+- Production deployment settings
+- Environment variable names
+- Destructive database migrations
+
+## Output format
+
+After completing work, respond with:
+
+1. Summary of backend changes
+2. Files changed
+3. Verification commands run
+4. Tests added or updated
+5. Risks, assumptions, or follow-ups

--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -11,7 +11,7 @@ You are a senior backend engineer working on this application.
 
 Your job is to design, implement, review, and debug backend code while keeping changes small, secure, testable, and consistent with the existing codebase.
 
-Before starting any task, read `CLAUDE.md` at the project root and `docs/plan/PROJECT_BRAIN.md` for product intent. If the task relates to a specific milestone, check `docs/plan/milestones/` and read the brief whose name or content best matches the current work. These documents define project conventions, stack, coding standards, and testing requirements that take precedence over general best practices.
+Before starting any task, read `CLAUDE.md` at the project root. Read `docs/plan/PROJECT_BRAIN.md` only when starting a new phase or when product intent is unclear. For routine implementation or review, read only the active milestone brief in `docs/plan/milestones/` plus `CLAUDE.md`. These documents take precedence over general best practices.
 
 ## Primary responsibilities
 

--- a/.claude/commands/source-control.md
+++ b/.claude/commands/source-control.md
@@ -36,9 +36,13 @@ Follow Conventional Commits as defined in `CLAUDE.md`:
 
 1. Push the branch: `git push -u origin <branch>`
 2. Create the PR: `gh pr create --title "..." --body "..."`
-3. The CI pipeline will automatically post `@github-copilot review` as a PR comment via `.github/workflows/copilot-review.yml`, triggering the Copilot review. No manual step needed.
+3. The CI pipeline will automatically post `@github-copilot review` on PR open/ready-for-review via `.github/workflows/copilot-review.yml`.
 4. Wait for CI checks and the Copilot review before merging.
 5. Address all review comments before merging (see PR review workflow in `CLAUDE.md`).
+6. If substantial changes are pushed after the initial review, trigger a follow-up Copilot review manually:
+   ```
+   gh pr comment <pr-number> --body "@github-copilot review"
+   ```
 
 ## What NOT to do
 

--- a/.claude/commands/source-control.md
+++ b/.claude/commands/source-control.md
@@ -32,6 +32,18 @@ Follow Conventional Commits as defined in `CLAUDE.md`:
 - Never push directly to `main`
 - Delete the remote branch after merging
 
+### Workflow
+
+1. Push the branch: `git push -u origin <branch>`
+2. Create the PR: `gh pr create --title "..." --body "..."`
+3. After the PR is created, request a Copilot code review by posting a comment on the PR:
+   ```
+   gh pr comment <pr-number> --body "@github-copilot review"
+   ```
+   Note: Copilot cannot be added as a reviewer directly because it is not a repository collaborator. Use the comment trigger instead.
+4. Wait for CI checks and the Copilot review before merging.
+5. Address all review comments before merging (see PR review workflow in `CLAUDE.md`).
+
 ## What NOT to do
 
 - Never force-push unless explicitly asked

--- a/.claude/commands/source-control.md
+++ b/.claude/commands/source-control.md
@@ -1,0 +1,40 @@
+# Source Control
+
+Follow these conventions when performing any git or GitHub operations in this project.
+
+## Branching
+
+- Always branch from `main` unless told otherwise.
+- Branch names must describe the work, not the tool or agent doing it.
+  - Good: `feat/add-agents`, `fix/auth-validation`, `refactor/remove-msal`
+  - Bad: `feat/add-claude-agents`, `feat/copilot-refactor`
+  - Do NOT label branches as tool-specific (e.g. "claude", "copilot", "codex") unless explicitly instructed.
+- Use the prefix that matches the change type:
+  - `feat/` — new feature or capability
+  - `fix/` — bug fix
+  - `refactor/` — code restructure without behavior change
+  - `chore/` — tooling, config, dependencies
+  - `docs/` — documentation only
+  - `test/` — tests only
+
+## Commits
+
+Follow Conventional Commits as defined in `CLAUDE.md`:
+- Format: `<type>(<scope>): <short summary>`
+- Imperative mood, max 72 chars, no trailing period
+- One logical change per commit
+- Every commit must leave the codebase in a working state
+
+## Pull Requests
+
+- PR title should match the branch intent, short and imperative
+- PR body must include a summary of changes and a test plan
+- Never push directly to `main`
+- Delete the remote branch after merging
+
+## What NOT to do
+
+- Never force-push unless explicitly asked
+- Never commit `.env.local` or files containing secrets
+- Never use `--no-verify` to skip hooks
+- Never amend a published commit

--- a/.claude/commands/source-control.md
+++ b/.claude/commands/source-control.md
@@ -9,7 +9,7 @@ Follow these conventions when performing any git or GitHub operations in this pr
   - Good: `feat/add-agents`, `fix/auth-validation`, `refactor/remove-msal`
   - Bad: `feat/add-claude-agents`, `feat/copilot-refactor`
   - Do NOT label branches as tool-specific (e.g. "claude", "copilot", "codex") unless explicitly instructed.
-- Use the prefix that matches the change type:
+- Use the prefix that matches the change type — these mirror the Conventional Commits types already used for commit messages in `CLAUDE.md`:
   - `feat/` — new feature or capability
   - `fix/` — bug fix
   - `refactor/` — code restructure without behavior change
@@ -36,11 +36,7 @@ Follow Conventional Commits as defined in `CLAUDE.md`:
 
 1. Push the branch: `git push -u origin <branch>`
 2. Create the PR: `gh pr create --title "..." --body "..."`
-3. After the PR is created, request a Copilot code review by posting a comment on the PR:
-   ```
-   gh pr comment <pr-number> --body "@github-copilot review"
-   ```
-   Note: Copilot cannot be added as a reviewer directly because it is not a repository collaborator. Use the comment trigger instead.
+3. The CI pipeline will automatically post `@github-copilot review` as a PR comment via `.github/workflows/copilot-review.yml`, triggering the Copilot review. No manual step needed.
 4. Wait for CI checks and the Copilot review before merging.
 5. Address all review comments before merging (see PR review workflow in `CLAUDE.md`).
 

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.pulls.requestReviewers({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              reviewers: ['copilot-pull-request-reviewer'],
+              issue_number: context.payload.pull_request.number,
+              body: '@github-copilot review',
             });


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/backend-engineer.md` — a Claude Code subagent definition for a senior backend engineer role, covering API routes, database, auth, validation, and testing
- Adds `.claude/commands/source-control.md` — a project-level skill with branching, commit, and PR conventions including the Copilot review workflow

## Test plan

- [ ] Verify `backend-engineer` subagent is selectable in Claude Code
- [ ] Verify `/source-control` skill loads correctly
- [ ] Confirm branch naming and PR workflow steps are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)